### PR TITLE
Fix default encoding problem in setup.py under Windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ Python library for unit-testing of XML document using lxml.
 from distutils.core import setup
 
 
-with open('README.txt') as fd:
+with open('README.txt', encoding='utf-8') as fd:
     long_description = fd.read()
 
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "setup.py", line 15, in <module>
    long_description = fd.read()
 File "C:\Python33\lib\encodings\cp1251.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 1577: character maps to <undefined>
```
