### PR TITLE
Handle namespaces

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -61,7 +61,7 @@ LXML version 2.x or 3.x?
 When dealing with version number, it appears that ``xmlunittest`` works with:
 
 * Python 2.7 and lxml 2.3.5 and above.
-* Pytonn 3.4 and lmxl 3.0 and above.
+* Python 3.4 and lmxl 3.0 and above.
 
 .. warning::
 

--- a/doc/xmlunittest.rst
+++ b/doc/xmlunittest.rst
@@ -186,10 +186,12 @@ Element assertions
 XPath expression assertions
 ===========================
 
-.. py:method:: XmlTestMixin.assertXpathsExist(node, xpaths)
+.. py:method:: XmlTestMixin.assertXpathsExist(node, xpaths, default_ns_prefix='ns')
 
    :param node: Element node
    :param tuple xpaths: List of XPath expressions
+   :param string default_ns_prefix: Optional, value of the default namespace
+      prefix
 
    Asserts each XPath from `xpaths` evaluates on `node` to at least one element
    or a not `None` value.
@@ -214,10 +216,12 @@ XPath expression assertions
       # ...
 
 
-.. py:method:: XmlTestMixin.assertXpathsOnlyOne(node, xpaths)
+.. py:method:: XmlTestMixin.assertXpathsOnlyOne(node, xpaths, default_ns_prefix='ns')
 
    :param node: Element node
    :param tuple xpaths: List of XPath expressions
+   :param string default_ns_prefix: Optional, value of the default namespace
+      prefix
 
    Asserts each XPath's result returns only one element.
 
@@ -241,10 +245,12 @@ XPath expression assertions
 
       # ...
 
-.. py:method:: XmlTestMixin.assertXpathsUniqueValue(node, xpaths)
+.. py:method:: XmlTestMixin.assertXpathsUniqueValue(node, xpaths, default_ns_prefix='ns')
 
    :param node: Element node
    :param tuple xpaths: List of XPath expressions
+   :param string default_ns_prefix: Optional, value of the default namespace
+      prefix
 
    Asserts each XPath's result's value is unique in the selected elements.
 
@@ -278,11 +284,13 @@ XPath expression assertions
       # ...
 
 
-.. py:method:: XmlTestMixin.assertXpathValues(node, xpath, values)
+.. py:method:: XmlTestMixin.assertXpathValues(node, xpath, values, default_ns_prefix='ns')
 
    :param node: Element node
    :param string xpath: XPath expression to select elements
    :param tuple values: List of accepted values
+   :param string default_ns_prefix: Optional, value of the default namespace
+      prefix
 
    Asserts each selected element's result from XPath expression is in the list
    of expected values.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ lxml>=2.3,<4.0
 tox>=1.8.1
 sphinx>=1.2.3
 isort>=4.2.5
-flake8>=3.0.8
+flake8>=3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pytest-cov>=1.8.1
 lxml>=2.3,<4.0
 tox>=1.8.1
 sphinx>=1.2.3
+isort>=4.2.5
+flake8>=3.0.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-lxml{30,34,3x}, py34-lxml{30,34,3x}
+envlist = py27-lxml{30,34,35,36,3x}, py34-lxml{30,34,35,36,3x}
 
 [testenv]
 
@@ -9,5 +9,7 @@ commands =
 deps =
     lxml30: lxml>=3.0,<3.1
     lxml34: lxml>=3.4,<3.5
+    lxml35: lxml>=3.5,<3.6
+    lxml36: lxml>=3.5,<3.6
     lxml3x: lxml<4.0
     pytest


### PR DESCRIPTION
These changes will improve the situation when it comes to test XML documents with namespaces:

* default namespace (xmlns=...) can be used in xpath expressions as `ns` (or with a custom prefix),
* named namespaces (xmlns:named=...) can be used in xpath expressions with their prefix, as long as they are defined for the root node the assertion is made with.