### PR TITLE
Update example code snippet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Example:
             </root>"""
 
             # Everything starts with `assertXmlDocument`
-            root = self.assertXmlDocument(data)
+            root = self.assertXmlDocument(data.encode())
 
             # Check namespace
             self.assertXmlNamespace(root, 'ns', 'uri')


### PR DESCRIPTION
This PR adds `.encode()` to the `data` string.

Without `.encode()`, the example code snippet throws a ValueError exception:
```ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.```