### PR TITLE
Fix: migrate from no longer lxml supported XPath.evaluate(node) to XPath as callable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest>=2.0.3
 pytest-cov>=1.8.1
-lxml>=2.3
+lxml==5.2.2
 tox>=1.8.1
 sphinx>=1.2.3
 isort>=4.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest>=2.0.3
 pytest-cov>=1.8.1
-lxml==5.2.2
+lxml>=4.0.0
 tox>=1.8.1
 sphinx>=1.2.3
 isort>=4.2.5

--- a/xmlunittest.py
+++ b/xmlunittest.py
@@ -148,7 +148,7 @@ class XmlTestMixin(object):
                                                    default_ns_prefix)
         for expression in expressions:
             try:
-                if not expression.evaluate(node):
+                if not expression(node):
                     self.fail_xpath_not_found(node, expression)
             except etree.XPathEvalError as error:
                 self.fail_xpath_error(node, expression.path, error)
@@ -161,7 +161,7 @@ class XmlTestMixin(object):
 
         for expression in expressions:
             try:
-                results = expression.evaluate(node)
+                results = expression(node)
             except etree.XPathEvalError as error:
                 self.fail_xpath_error(node, expression.path, error)
 
@@ -187,7 +187,7 @@ class XmlTestMixin(object):
 
         for expression in expressions:
             try:
-                results = expression.evaluate(node)
+                results = expression(node)
             except etree.XPathEvalError as error:
                 self.fail_xpath_error(node, expression.path, error)
 
@@ -204,7 +204,7 @@ class XmlTestMixin(object):
                                                  xpath,
                                                  default_ns_prefix)
         try:
-            results = expression.evaluate(node)
+            results = expression(node)
         except etree.XPathEvalError as error:
             self.fail_xpath_error(node, expression.path, error)
 


### PR DESCRIPTION
XPath.evaluate is no longer in `lxml`, now the XPath expression is callable directly.

First, thank you very much for making this project. I am actually not familiar with it, but I'm trying to fix  [InvoiceGenerator](https://pypi.org/project/InvoiceGenerator/) which I'm actually not that familiar with as well, but I'm trying to fix it and then use it.

Please swiftly merge and bump and release pypi package, in order for me to upgrade it in the other project and be able to use it.

Thank you for being a good mantainer.

Kind regards.