### PR TITLE
Fix for issue #17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,12 @@ requires = ["setuptools~=66.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
+py-modules = ["xmlunittest"]
 platforms = ["Linux x86, x86-64"]
-
-[tool.setuptools.packages.find]
-include = ["xmlunittest"]
-namespaces = false
 
 [project]
 name = "xmlunittest"
-version = "1.0.0"
+version = "1.0.1"
 description = "Library using lxml and unittest for unit testing XML."
 maintainers = [
   { name="Florian Strzelecki" },


### PR DESCRIPTION
 https://github.com/Exirel/python-xmlunittest/issues/17
 
 xmlunittest module was not being installed into site-packages.
Moved setuptools configuration to use py-modules.

ci.yaml should potentially be updated so that unit tests are not run in same path as xmlunittest.py. This is why the issue was not originally caught.