### PR TITLE
docs: use sphinx's autodoc extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,9 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = [
+    'sphinx.ext.autodoc',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/xmlunittest.rst
+++ b/docs/xmlunittest.rst
@@ -4,320 +4,39 @@
 Test assertions
 ===============
 
-.. py:class:: XmlTestCase
+.. autoclass:: XmlTestCase
 
-   Base class one can extends to use XML assertion methods. As this class
-   only provide `assert*` methods, there is nothing more to do.
-
-   Simple as it always should be.
-
-   This class extends :py:class:`unittest.TestCase` and
-   :py:class:`XmlTestMixin`. If you want a description of assertion methods,
-   you should read next the description of base class :py:class:`XmlTestMixin`.
-
-
-.. py:class:: XmlTestMixin
-
-   Base class that only provide assertion methods. To use, one must extends
-   both :py:class:`unittest.TestCase` and :py:class:`XmlTestMixin`. Of course,
-   it can use any subclass of :py:class:`unittest.TestCase`, in combination
-   with :py:class:`XmlTestMixin` without effort.
-
-   For example::
-
-      class TestUsingMixin(unittest.TestCase, xmlunittest.XmlTestMixin):
-
-          def test_my_test(self):
-              data = my_module.generate_xml()
-
-              # unittest.TestCase assert
-              self.assertIsNotNone(data)
-
-              # xmlunittest.XmlTestMixin assert
-              self.assertXmlDocument(data)
+.. autoclass:: XmlTestMixin
 
 
 Document assertions
 ===================
 
-.. py:method:: XmlTestMixin.assertXmlDocument(data)
+.. automethod:: XmlTestMixin.assertXmlDocument
 
-   :param string data: XML formated string
-   :rtype: lxml.etree._Element
-
-   Assert `data` is a valid XML formated string. This method will parse string
-   with `lxml.etree.fromstring`. If parsing failed (raise an XMLSyntaxError),
-   the test fails.
-
-
-.. py:method:: XmlTestMixin.assertXmlPartial(partial_data, root_tag=None)
-
-   :param string partial_data: Partial document as XML formated string
-   :rtype: lxml.etree._Element
-
-   Assert `partial_data` is a partially XML formated string. This method will
-   encapsulate the string into a root element, and then try to parse the string
-   as a normal XML document.
-
-   If the parsing failed, test will fail. If the parsing's result does not
-   have any element child, the test will also fail, because it expects a
-   *partial document**, not just a string.
-
-   .. rubric:: Optional named arguments
-
-   :param string root_tag: Optional, root element's tag name
-
-   One can provide the root element's tag name to the method for their own
-   convenience.
-
-   .. rubric:: Example
-
-   ::
-
-      # ...
-
-      def test_custom_test(self):
-          data = """
-             <partial>a</partial>
-             <partial>b</partial>
-          """
-
-          root = self.assertXmlPartial(data)
-          # Make some assert on the result's document.
-          self.assertXpathValues(root, './partial/text()', ('a', 'b'))
-
-      # ...
+.. automethod:: XmlTestMixin.assertXmlPartial
 
 
 Element assertions
 ==================
 
-.. py:method:: XmlTestMixin.assertXmlNamespace(node, prefix, uri)
+.. automethod:: XmlTestMixin.assertXmlNamespace
 
-   :param node: Element node
-   :param string prefix: Expected namespace's prefix
-   :param string uri: Expected namespace's URI
+.. automethod:: XmlTestMixin.assertXmlHasAttribute
 
-   Asserts `node` declares namespace `uri` using `prefix`.
-
-   .. rubric:: Example
-
-   ::
-
-      # ...
-
-      def test_custom_test(self):
-          data = """<?xml version="1.0" encoding="UTF-8" ?>
-          <root xmlns:ns="uri"/>"""
-
-          root = self.assertXmlDocument(data)
-
-          self.assertXmlNamespace(root, 'ns', 'uri')
-
-      # ...
-
-.. py:method:: XmlTestMixin.assertXmlHasAttribute(node, attribute, **kwargs)
-
-   :param node: Element node
-   :param string attribute: Expected attribute's name (using `prefix:name`
-      notation
-
-   Asserts `node` has the given `attribute`.
-
-   Argument `attribute` must be the attribute's name, with namespace's prefix
-   (notation 'ns:att' and not '{uri}att').
-
-   .. rubric:: Optional named arguments
-
-   :param string expected_value: Optional, expected attribute's value
-   :param tuple expected_values: Optional, list of accepted attribute's value
-
-   `expected_value` and `expected_values` are mutually exclusive.
-
-   .. rubric:: Example
-
-   ::
-
-      # ...
-
-      def test_custom_test(self):
-         data = """<root a="1" />"""
-         root = self.assertXmlDocument(data)
-
-         # All these tests will pass
-         self.assertXmlHasAttribute(root, 'a')
-         self.assertXmlHasAttribute(root, 'a', expected_value='1')
-         self.assertXmlHasAttribute(root, 'a', expected_values=('1', '2'))
-
-      # ...
-
-
-.. py:method:: XmlTestMixin.assertXmlNode(node, **kwargs)
-
-   Asserts `node` is an element node, and can assert expected tag and value.
-
-   .. rubric:: Optional named arguments
-
-   :param string tag: Expected node's tag name
-   :param string text: Expected node's text value
-   :param tuple text_in: Accepted node's text values
-
-   `text` and `text_in` are mutually exclusive.
-
-   .. rubric:: Example
-
-   ::
-
-      # ...
-
-      def test_custom_test(self):
-         data = """<root>some_value</root>"""
-         root = self.assertXmlDocument(data)
-
-         # All these tests will pass
-         self.assertXmlNode(root)
-         self.assertXmlNode(root, tag='root')
-         self.assertXmlNode(root, tag='root', text='some_value')
-         self.assertXmlNode(root, tag='root', text_in=('some_value', 'other'))
-
-      # ...
+.. automethod:: XmlTestMixin.assertXmlNode
 
 
 XPath expression assertions
 ===========================
 
-.. py:method:: XmlTestMixin.assertXpathsExist(node, xpaths, default_ns_prefix='ns')
+.. automethod:: XmlTestMixin.assertXpathsExist
 
-   :param node: Element node
-   :param tuple xpaths: List of XPath expressions
-   :param string default_ns_prefix: Optional, value of the default namespace
-      prefix
+.. automethod:: XmlTestMixin.assertXpathsOnlyOne
 
-   Asserts each XPath from `xpaths` evaluates on `node` to at least one element
-   or a not `None` value.
+.. automethod:: XmlTestMixin.assertXpathsUniqueValue
 
-   .. rubric:: Example
-
-   ::
-
-      # ...
-
-      def test_custom_test(self):
-         data = """<root rootAtt="value">
-            <child>value</child>
-            <child att="1"/>
-            <child att="2"/>
-         </root>"""
-         root = self.assertXmlDocument(data)
-
-         # All these XPath expression returns a not `None` value.
-         self.assertXpathsExist(root, ('@rootAtt', './child', './child[@att="1"]'))
-
-      # ...
-
-
-.. py:method:: XmlTestMixin.assertXpathsOnlyOne(node, xpaths, default_ns_prefix='ns')
-
-   :param node: Element node
-   :param tuple xpaths: List of XPath expressions
-   :param string default_ns_prefix: Optional, value of the default namespace
-      prefix
-
-   Asserts each XPath's result returns only one element.
-
-
-   .. rubric:: Example
-
-   ::
-
-      # ...
-
-      def test_custom_test(self):
-         data = """<root>
-            <child att="1"/>
-            <child att="2"/>
-            <unique>this element is unique</unique>
-         </root>"""
-         root = self.assertXmlDocument(data)
-
-         # All these XPath expression returns only one result
-         self.assertXpathsOnlyOne(root, ('./unique', './child[@att="1"]'))
-
-      # ...
-
-.. py:method:: XmlTestMixin.assertXpathsUniqueValue(node, xpaths, default_ns_prefix='ns')
-
-   :param node: Element node
-   :param tuple xpaths: List of XPath expressions
-   :param string default_ns_prefix: Optional, value of the default namespace
-      prefix
-
-   Asserts each XPath's result's value is unique in the selected elements.
-
-   One can use this method to check node's value, and node's attribute's value,
-   in a set of nodes selected by XPath expression.
-
-   .. rubric:: Example
-
-   ::
-
-      # ...
-
-      def test_custom_test(self):
-         data = """<?xml version="1.0" encoding="UTF-8" ?>
-         <root>
-            <sub subAtt="unique" id="1">unique 1</sub>
-            <sub subAtt="notUnique" id="2">unique 2</sub>
-            <sub subAtt="notUnique" id="3">unique 3</sub>
-            <multiple>twice</multiple>
-            <multiple>twice</multiple>
-         </root>"""
-         root = self.assertXmlDocument(data)
-
-         # This will pass
-         self.assertXpathsUniqueValue(root, ('./sub/@id', './sub/text()'))
-
-         # These won't pass
-         self.assertXpathsUniqueValue(root, ('./sub/@subAtt',))
-         self.assertXpathsUniqueValue(root, ('./multiple/text()',))
-
-      # ...
-
-
-.. py:method:: XmlTestMixin.assertXpathValues(node, xpath, values, default_ns_prefix='ns')
-
-   :param node: Element node
-   :param string xpath: XPath expression to select elements
-   :param tuple values: List of accepted values
-   :param string default_ns_prefix: Optional, value of the default namespace
-      prefix
-
-   Asserts each selected element's result from XPath expression is in the list
-   of expected values.
-
-
-   .. rubric:: Example
-
-   ::
-
-      # ...
-
-      def test_custom_test(self):
-         data = """<?xml version="1.0" encoding="UTF-8" ?>
-         <root>
-            <sub id="1">a</sub>
-            <sub id="2">a</sub>
-            <sub id="3">b</sub>
-            <sub id="4">c</sub>
-         </root>"""
-         root = self.assertXmlDocument(data)
-
-         # Select attribute's value
-         self.assertXpathValues(root, './sub/@id', ('1', '2', '3', '4'))
-         # Select node's text value
-         self.assertXpathValues(root, './sub/text()', ('a', 'b', 'c'))
-
-      # ...
+.. automethod:: XmlTestMixin.assertXpathValues
 
 
 XML schema conformance assertion
@@ -335,168 +54,11 @@ according to a schema. Any validation schema language that is supported by
 Please read `Validation with lxml <http://lxml.de/validation.html>`_ to build
 your own schema objects in these various schema languages.
 
+.. automethod:: XmlTestMixin.assertXmlValidDTD
 
-.. py:method:: XmlTestMixin.assertXmlValidDTD(node, dtd=None, filename=None)
+.. automethod:: XmlTestMixin.assertXmlValidXSchema
 
-   :param node: Node element to valid using a DTD
-   :type node: :py:class:`lxml.etree.Element`
-
-   Asserts that the given `node` element can be validated successfuly by
-   the given DTD.
-
-   The DTD can be provided as a simple string, or as a previously parsed DTD
-   using :py:class:`lxml.etree.DTD`. It can be also provided by a filename.
-
-   .. rubric:: Optional arguments
-
-   One can provide either a DTD as a string, or a DTD element from LXML, or
-   the filename of the DTD.
-
-   :param dtd: DTD used to valid the given node element.
-               Can be a string or an LXML DTD element
-   :type dtd: `string` | :py:class:`lxml.etree.DTD`
-   :param string filename: Path to the expected DTD for validation.
-
-   `dtd` and `filename` are mutualy exclusive.
-
-   .. rubric:: Example using a filename
-
-   ::
-
-      def my_custom_test(self):
-          """Check XML generated using DTD at path/to/file.dtd.
-
-          The content of the DTD file is:
-
-              <!ELEMENT root (child)>
-              <!ELEMENT child EMPTY>
-              <!ATTLIST child id ID #REQUIRED>
-
-          """
-          dtd_filename = 'path/to/file.dtd'
-          data = b"""<?xml version="1.0" encoding="utf-8"?>
-          <root>
-             <child id="child1"/>
-          </root>
-          """
-          root = test_case.assertXmlDocument(data)
-          self.assertXmlValidDTD(root, filename=dtd_filename)
-
-
-.. py:method:: XmlTestMixin.assertXmlValidXSchema(node, xschema=None, filename=None)
-
-   :param node: Node element to valid using an XML Schema
-   :type node: :py:class:`lxml.etree.Element`
-
-   Asserts that the given `node` element can be validated successfuly by
-   the given XML Schema.
-
-   The XML Schema can be provided as a simple string, or as a previously parsed
-   XSchema using :py:class:`lxml.etree.XMLSChema`. It can be also provided by a
-   filename.
-
-   .. rubric:: Optional arguments
-
-   One can provide either an XMLSchema as a string, or an XMLSchema element
-   from LXML, or the filename of the XMLSchema.
-
-   :param xschema: XMLSchema used to valid the given node element.
-                   Can be a string or an LXML XMLSchema element
-   :type xschema: `string` | :py:class:`lxml.etree.XMLSchema`
-   :param string filename: Path to the expected XMLSchema for validation.
-
-   `xschema` and `filename` are mutualy exclusive.
-
-   .. rubric:: Example using a filename
-
-   ::
-
-      def my_custom_test(self):
-          """Check XML generated using XMLSchema at path/to/xschema.xml.
-
-          The content of the XMLSchema file is:
-
-            <?xml version="1.0" encoding="utf-8"?>
-            <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-               <xsd:element name="root">
-                   <xsd:complexType>
-                       <xsd:sequence>
-                           <xsd:element name="child" minOccurs="1" maxOccurs="1">
-                               <xsd:complexType>
-                                   <xsd:simpleContent>
-                                       <xsd:extension base="xsd:string">
-                                           <xsd:attribute name="id" type="xsd:string" use="required" />
-                                       </xsd:extension>
-                                   </xsd:simpleContent>
-                               </xsd:complexType>
-                           </xsd:element>
-                       </xsd:sequence>
-                   </xsd:complexType>
-               </xsd:element>
-            </xsd:schema>
-
-          """
-          xschema_filename = 'path/to/xschema.xml'
-          data = b"""<?xml version="1.0" encoding="utf-8"?>
-          <root>
-             <child id="child1"/>
-          </root>
-          """
-          root = test_case.assertXmlDocument(data)
-          self.assertXmlValidXSchema(root, filename=xschema_filename)
-
-
-.. py:method:: XmlTestMixin.assertXmlValidRelaxNG(node, relaxng=None, filename=None)
-
-   :param node: Node element to valid using a RelaxNG
-   :type node: :py:class:`lxml.etree.Element`
-
-   Asserts that the given `node` element can be validated successfuly by
-   the given RelaxNG.
-
-   The RelaxNG can be provided as a simple string, or as a previously parsed
-   RelaxNG using :py:class:`lxml.etree.RelaxNG`. It can be also provided by a
-   filename.
-
-   .. rubric:: Optional arguments
-
-   One can provide either a RelaxNG as a string, or a RelaxNG element
-   from LXML, or the filename of the RelaxNG.
-
-   :param relaxng: RelaxNG used to valid the given node element.
-                   Can be a string or an LXML RelaxNG element
-   :type relaxng: `string` | :py:class:`lxml.etree.RelaxNG`
-   :param string filename: Path to the expected RelaxNG for validation.
-
-   `relaxng` and `filename` are mutualy exclusive.
-
-   .. rubric:: Example using a filename
-
-   ::
-
-      def my_custom_test(self):
-          """Check XML generated using RelaxNG at path/to/relaxng.xml.
-
-          The content of the RelaxNG file is:
-
-              <?xml version="1.0" encoding="utf-8"?>
-              <rng:element name="root" xmlns:rng="http://relaxng.org/ns/structure/1.0">
-                  <rng:element name="child">
-                      <rng:attribute name="id">
-                          <rng:text />
-                      </rng:attribute>
-                  </rng:element>
-              </rng:element>
-
-          """
-          relaxng_filename = 'path/to/relaxng.xml'
-          data = b"""<?xml version="1.0" encoding="utf-8"?>
-          <root>
-             <child id="child1"/>
-          </root>
-          """
-          root = test_case.assertXmlDocument(data)
-          self.assertXmlValidRelaxNG(root, filename=relaxng_filename)
+.. automethod:: XmlTestMixin.assertXmlValidRelaxNG
 
 
 XML documents comparison assertion
@@ -517,58 +79,4 @@ And as always, remember that the whole purpose of this :py:mod:`xmlunittest`
 is to **avoid** any comparison of XML formated strings. But, whatever, this
 function could help. Maybe.
 
-.. py:method:: XmlTestMixin.assertXmlEquivalentOutputs(data, expected)
-
-   :param string data: XML formated string to check
-   :param string expected: XML formated string used as reference
-
-   Asserts both XML formated string are equivalent. The comparison ignores
-   spaces within nodes and namespaces may be associated to diffrerent prefixes,
-   thus requiring only the same URL.
-
-   If a difference is found, an :py:exc:`AssertionError` is raised, with the
-   comparison failure's message as error's message.
-
-   .. note::
-
-      The name ``assertXmlEquivalentOutputs`` is cleary a way to prevent user
-      to missunderstand the meaning of this assertion: it checks only similar
-      **outputs**, not **document**.
-
-   .. note::
-
-      This method only accept ``string`` as arguments. This is an opinionated
-      implementation choice, as the purpose of this method is to check
-      the result outputs of an XML document.
-
-
-   .. rubric:: Example
-
-   ::
-
-      # ...
-
-      def test_custom_test(self):
-          """Same XML (with different spacings placements and attrs order)"""
-          # This XML string should come from the code one want to test
-          data = b"""<?xml version="1.0" encoding="UTF-8" ?>
-          <root><tag bar="foo" foo="bar"> foo </tag></root>"""
-
-          # This is the former XML document one can expect, with pretty print
-          expected = b"""<?xml version="1.0" encoding="UTF-8" ?>
-          <root>
-              <tag foo="bar" bar="foo">foo</tag>
-          </root>"""
-
-          # This will pass
-          test_case.assertXmlEquivalentOutputs(data, expected)
-
-          # This is another example of result, with a missing attribute
-          data = b"""<?xml version="1.0" encoding="UTF-8" ?>
-          <root>
-              <tag foo="bar"> foo </tag>
-          </root>
-          """
-
-          # This won't pass
-          test_case.assertXmlEquivalentOutputs(data, expected)
+.. automethod:: XmlTestMixin.assertXmlEquivalentOutputs(data, expected)

--- a/src/xmlunittest.py
+++ b/src/xmlunittest.py
@@ -1,10 +1,16 @@
 """Unittest module for XML testing purpose."""
+from __future__ import annotations
+
 import io
 import unittest
+from typing import TYPE_CHECKING
 
 from lxml import etree
 from lxml.doctestcompare import PARSE_XML, LXMLOutputChecker
 from lxml.etree import XMLSyntaxError, XPathSyntaxError
+
+if TYPE_CHECKING:
+    from typing import Any, Union
 
 __all__ = ['XmlTestMixin', 'XmlTestCase']
 
@@ -12,8 +18,23 @@ __all__ = ['XmlTestMixin', 'XmlTestCase']
 class XmlTestMixin:
     """Base mixin class for XML unittest.
 
-    One may want to extends unittest.TestCase itself, and then uses this
-    mixin class to add specific XML assertions.
+    This class provides assertion methods only. To use, one must extends
+    both :py:class:`unittest.TestCase` and :py:class:`XmlTestMixin`. Of course,
+    it can use any subclass of :py:class:`unittest.TestCase`, in combination
+    with :py:class:`XmlTestMixin`.
+
+    For example::
+
+      class TestUsingMixin(unittest.TestCase, xmlunittest.XmlTestMixin):
+
+          def test_my_test(self):
+              data: bytes = my_module.generate_xml()
+
+              # unittest.TestCase assert
+              self.assertIsNotNone(data)
+
+              # xmlunittest.XmlTestMixin assert
+              self.assertXmlDocument(data)
     """
     default_partial_tag = 'partialTest'
     error_encoding = 'utf-8'
@@ -68,10 +89,29 @@ class XmlTestMixin:
         except XPathSyntaxError as error:
             self.fail_xpath_error(node, xpath, error)
 
-    def assertXmlDocument(self, data):
-        """Asserts `data` is an XML document and returns it.
+    def assertXmlDocument(self, data: bytes):
+        """Assert ``data`` is an XML document and return it.
 
-        Assertion and XML parsing using lxml.
+        :param data: XML formated string
+
+        Assert ``data`` is a valid XML formated string. This method will parse
+        string with ``lxml.etree.fromstring``. If parsing failed (raise an
+        ``XMLSyntaxError``), the test fails::
+
+            class CustomTestCase(XmlTestCase):
+
+                def test_my_custom_test(self):
+                    # generate a XML formatted string from your code
+                    data: bytes = this_is_your_function()
+
+                    # start with `assertXmlDocument`
+                    root = self.assertXmlDocument(data)
+
+        .. note::
+
+            This assertion method requires a :class:`bytes`, as your string
+            should be properly encoded first.
+
         """
         # no assertion yet
         try:
@@ -81,8 +121,45 @@ class XmlTestMixin:
 
         return doc
 
-    def assertXmlPartial(self, partial_data, root_tag=None):
-        """Asserts `data` is an XML partial document, and returns result."""
+    def assertXmlPartial(
+        self,
+        partial_data: str,
+        root_tag: Union[str, None] = None,
+    ):
+        """Assert ``data`` is an XML partial document, and return result.
+
+        :param partial_data: Partial document as XML formated string
+        :param root_tag: Optional, root element's tag name
+
+        This method encapsulates the ``partial_data`` into a root element then
+        parse the string as an XML document.
+
+        By default, this method uses :attr:`default_partial_tag` as the root
+        element's tag name, or you can provide a ``root_tag``.
+
+        If the parsing fails, the test will fail. If the parsing's result does
+        not have any child element, the test will also fail, because it expects
+        a **partial document**, and not just a string.
+
+        .. rubric:: Example
+
+        ::
+
+            # ...
+
+            def test_custom_test(self):
+                data = \"\"\"
+                    <partial>a</partial>
+                    <partial>b</partial>
+                \"\"\"
+
+                root = self.assertXmlPartial(data)
+                # Make some assert on the result's document.
+                self.assertXpathValues(root, './partial/text()', ('a', 'b'))
+
+            # ...
+
+        """
         tag_name = (
             root_tag if root_tag is not None
             else self.default_partial_tag)
@@ -99,47 +176,175 @@ class XmlTestMixin:
 
         return doc
 
-    def assertXmlNamespace(self, node, prefix, uri):
-        """Asserts `node` declares namespace `uri` using `prefix`.
+    def assertXmlNamespace(self, node, prefix: str, uri: str):
+        """Assert ``node`` declares a namespace ``uri`` using ``prefix``.
 
-        One can use this method on element node.
+        :param node: Element node
+        :param prefix: Expected namespace's prefix
+        :param uri: Expected namespace's URI
+
+        .. rubric:: Example
+
+        ::
+
+            # ...
+
+            def test_custom_test(self):
+                data = \"\"\"<?xml version="1.0" encoding="UTF-8" ?>
+                <root xmlns:ns="uri"/>\"\"\"
+
+                root = self.assertXmlDocument(data.encode('utf-8)'))
+
+                self.assertXmlNamespace(root, 'ns', 'uri')
+
+            # ...
         """
         self.assertIn(prefix, node.nsmap)
         self.assertEqual(node.nsmap.get(prefix), uri)
 
-    def assertXmlHasAttribute(self, node, attribute, **kwargs):
-        """Asserts `node` has the given `attribute`.
+    def assertXmlHasAttribute(
+        self,
+        node,
+        attribute:  str,
+        *,
+        expected_value: Union[str, None] = None,
+        expected_values: Union[str, None] = None,
+    ):
+        """Assert ``node`` has the given ``attribute``.
 
-        Argument `attribute` must be the attribute's name, with
-        namespace's prefix (notation 'ns:att' and not '{uri}att').
+        :param node: Element node
+        :param attribute: Expected attribute's name (using ``prefix:name``
+                          notation)
+        :param expected_value: Optional, expected attribute's value
+        :param expected_values: Optional, list of accepted attribute's value
+
+        Argument ``attribute`` must be the attribute's name, with
+        namespace's prefix (notation ``'ns:att'`` and not ``'{uri}att'``).
+
+        .. note::
+
+            If ``expected_value`` is not ``None``, then ``expected_values``
+            will be ignored.
+
+        .. rubric:: Example
+
+        ::
+
+            # ...
+
+            def test_custom_test(self):
+                data = \"\"\"<root a="1" />\"\"\"
+                root = self.assertXmlDocument(data.encode('utf-8'))
+
+                # All these tests will pass
+                self.assertXmlHasAttribute(root, 'a')
+                self.assertXmlHasAttribute(root, 'a', expected_value='1')
+                self.assertXmlHasAttribute(
+                    root, 'a', expected_values=('1', '2')
+                )
+
+            # ...
+
         """
         self.assertIn(attribute, node.attrib)
 
-        if 'expected_value' in kwargs:
-            self.assertEqual(node.attrib.get(attribute),
-                             kwargs.get('expected_value'))
-        elif 'expected_values' in kwargs:
-            self.assertIn(node.attrib.get(attribute),
-                          kwargs.get('expected_values'))
+        if expected_value is not None:
+            self.assertEqual(node.attrib.get(attribute), expected_value)
 
-    def assertXmlNode(self, node, **kwargs):
-        """Asserts `node` is an element node with expected tag and value."""
+        elif expected_values is not None:
+            self.assertIn(node.attrib.get(attribute), expected_values)
+
+    def assertXmlNode(
+        self,
+        node: Any,
+        *,
+        tag: Union[str, None] = None,
+        text: Union[str, None] = None,
+        text_in: Union[tuple, None] = None,
+    ):
+        """Assert ``node`` is an element node.
+
+        :param node: Element node
+        :param tag: Expected node's tag name
+        :param text: Expected node's text value
+        :param text_in: Accepted node's text values
+
+        This method tests that ``node`` is an element node. It can also test
+        that it has the expected ``tag`` and/or ``text``, and/or that the text
+        is one of ``text_in``.
+
+        .. rubric:: Example
+
+        ::
+
+            # ...
+
+            def test_custom_test(self):
+                data = \"\"\"<root>some_value</root>\"\"\"
+                root = self.assertXmlDocument(data.encode('utf-8'))
+
+                # All these tests will pass
+                self.assertXmlNode(root)
+                self.assertXmlNode(root, tag='root')
+                self.assertXmlNode(root, tag='root', text='some_value')
+                self.assertXmlNode(
+                    root, tag='root', text_in=('some_value', 'other')
+                )
+
+            # ...
+
+        """
         # Assert `node` is an element node and not None or a string or
         # anything like this
         self.assertIsInstance(node, etree._Element)
 
-        if 'tag' in kwargs:
-            tag = kwargs.get('tag')
+        if tag is not None:
             self.assertEqual(node.tag, tag)
 
-        if 'text' in kwargs:
-            self.assertEqual(node.text, kwargs.get('text'))
+        if text is not None:
+            self.assertEqual(node.text, text)
 
-        if 'text_in' in kwargs:
-            self.assertIn(node.text, kwargs.get('text_in'))
+        if text_in is not None:
+            self.assertIn(node.text, text_in)
 
-    def assertXpathsExist(self, node, xpaths, default_ns_prefix='ns'):
-        """Asserts each XPath is valid for element `node`."""
+    def assertXpathsExist(
+        self,
+        node,
+        xpaths: tuple,
+        default_ns_prefix: str = 'ns',
+    ):
+        """Assert at least one value is found for each ``xpaths``.
+
+        :param node: Element node
+        :param xpaths: List of XPath expressions
+        :param default_ns_prefix: Optional, value of the default namespace
+                                  prefix
+
+        This method tests that all XPath expressions from ``xpaths``
+        evaluate on ``node`` to at least one element or a not ``None`` value.
+
+        .. rubric:: Example
+
+        ::
+
+            # ...
+
+            def test_custom_test(self):
+                data = \"\"\"<root rootAtt="value">
+                    <child>value</child>
+                    <child att="1"/>
+                    <child att="2"/>
+                </root>\"\"\"
+                root = self.assertXmlDocument(data.encode('utf-8'))
+
+                # All these XPath expression returns a not `None` value.
+                self.assertXpathsExist(
+                    root, ('@rootAtt', './child', './child[@att="1"]')
+                )
+
+            # ...
+
+        """
         expressions = self.build_xpath_expressions(node,
                                                    xpaths,
                                                    default_ns_prefix)
@@ -150,8 +355,40 @@ class XmlTestMixin:
             except etree.XPathEvalError as error:
                 self.fail_xpath_error(node, expression.path, error)
 
-    def assertXpathsOnlyOne(self, node, xpaths, default_ns_prefix='ns'):
-        """Asserts each xpath's result returns only one element."""
+    def assertXpathsOnlyOne(
+        self,
+        node,
+        xpaths: tuple,
+        default_ns_prefix: str = 'ns',
+    ):
+        """Assert ``xpaths`` expressions return only one element each.
+
+        :param node: Element node
+        :param xpaths: List of XPath expressions
+        :param default_ns_prefix: Optional, value of the default namespace
+                                  prefix
+
+        .. rubric:: Example
+
+        ::
+
+            # ...
+
+            def test_custom_test(self):
+                data = \"\"\"<root>
+                    <child att="1"/>
+                    <child att="2"/>
+                    <unique>this element is unique</unique>
+                </root>\"\"\"
+                root = self.assertXmlDocument(data.encode('utf-8'))
+
+                # All these XPath expression returns only one result
+                self.assertXpathsOnlyOne(
+                    root, ('./unique', './child[@att="1"]')
+                )
+
+            # ...
+        """
         expressions = self.build_xpath_expressions(node,
                                                    xpaths,
                                                    default_ns_prefix)
@@ -176,8 +413,50 @@ class XmlTestMixin:
                                   expression.path,
                                   etree.tostring(node, pretty_print=True)))
 
-    def assertXpathsUniqueValue(self, node, xpaths, default_ns_prefix='ns'):
-        """Asserts each xpath's value is unique in the selected elements."""
+    def assertXpathsUniqueValue(
+        self,
+        node,
+        xpaths: tuple,
+        default_ns_prefix: str = 'ns',
+    ):
+        """Assert values found by ``xpaths`` are unique per XPath expression.
+
+        :param node: Element node
+        :param xpaths: List of XPath expressions
+        :param default_ns_prefix: Optional, value of the default namespace
+                                  prefix
+
+        This method tests that all the values are unique per XPath expression.
+
+        .. rubric:: Example
+
+        ::
+
+            # ...
+
+            def test_custom_test(self):
+                data = \"\"\"<?xml version="1.0" encoding="UTF-8" ?>
+                <root>
+                    <sub subAtt="unique" id="1">unique 1</sub>
+                    <sub subAtt="notUnique" id="2">unique 2</sub>
+                    <sub subAtt="notUnique" id="3">unique 3</sub>
+                    <multiple>twice</multiple>
+                    <multiple>twice</multiple>
+                </root>\"\"\"
+                root = self.assertXmlDocument(data.encode('utf-8'))
+
+                # This will pass
+                self.assertXpathsUniqueValue(
+                    root, ('./sub/@id', './sub/text()')
+                )
+
+                # These won't pass
+                self.assertXpathsUniqueValue(root, ('./sub/@subAtt',))
+                self.assertXpathsUniqueValue(root, ('./multiple/text()',))
+
+            # ...
+
+        """
         expressions = self.build_xpath_expressions(node,
                                                    xpaths,
                                                    default_ns_prefix)
@@ -195,8 +474,48 @@ class XmlTestMixin:
                           % (node.tag, expression.path,
                              etree.tostring(node, pretty_print=True)))
 
-    def assertXpathValues(self, node, xpath, values, default_ns_prefix='ns'):
-        """Asserts each xpath's value is in the expected values."""
+    def assertXpathValues(
+        self,
+        node,
+        xpath: str,
+        values: tuple,
+        default_ns_prefix: str = 'ns',
+    ):
+        """Assert all values found by ``xpath`` match expected ``values``.
+
+        :param node: Element node
+        :param xpath: XPath expression to select elements
+        :param values: List of accepted values
+        :param default_ns_prefix: Optional, value of the default namespace
+                                  prefix
+
+        This method tests if all the values found from the given XPath
+        expression match any element in ``values``.
+
+        .. rubric:: Example
+
+        ::
+
+            # ...
+
+            def test_custom_test(self):
+                data = \"\"\"<?xml version="1.0" encoding="UTF-8" ?>
+                <root>
+                    <sub id="1">a</sub>
+                    <sub id="2">a</sub>
+                    <sub id="3">b</sub>
+                    <sub id="4">c</sub>
+                </root>\"\"\"
+                root = self.assertXmlDocument(data.encode('utf-8'))
+
+                # Select attribute's value
+                self.assertXpathValues(root, './sub/@id', ('1', '2', '3', '4'))
+                # Select node's text value
+                self.assertXpathValues(root, './sub/text()', ('a', 'b', 'c'))
+
+            # ...
+
+        """
         expression = self.build_xpath_expression(node,
                                                  xpath,
                                                  default_ns_prefix)
@@ -215,7 +534,41 @@ class XmlTestMixin:
                              etree.tostring(node, pretty_print=True)))
 
     def assertXmlValidDTD(self, node, dtd=None, filename=None):
-        """Asserts XML node is valid according to the given DTD."""
+        """Assert XML node is valid according to a DTD.
+
+        :param node: Node element to valid using a DTD
+        :param dtd: DTD used to valid the given node element. Can be a string
+                    or an LXML DTD element
+        :param filename: Path to the expected DTD for validation.
+
+        This method tests if the given ``node`` complies with a DTD.
+        This DTD can be provided as a string, as a :py:class:`lxml.etree.DTD`
+        object, or from a file (with the ``filename`` parameter).
+
+        .. rubric:: Example using a filename
+
+        ::
+
+            def my_custom_test(self):
+                \"\"\"Check XML generated using DTD at path/to/file.dtd.
+
+                The content of the DTD file is:
+
+                    <!ELEMENT root (child)>
+                    <!ELEMENT child EMPTY>
+                    <!ATTLIST child id ID #REQUIRED>
+
+                \"\"\"
+                dtd_filename = 'path/to/file.dtd'
+                data = \"\"\"<?xml version="1.0" encoding="utf-8"?>
+                <root>
+                    <child id="child1"/>
+                </root>
+                \"\"\"
+                root = test_case.assertXmlDocument(data.encode('utf-8'))
+                self.assertXmlValidDTD(root, filename=dtd_filename)
+
+        """
         schema = None
 
         if isinstance(dtd, etree.DTD):
@@ -235,7 +588,65 @@ class XmlTestMixin:
 
     def assertXmlValidXSchema(self, node, xschema=None, filename=None,
                               encoding='utf-8'):
-        """Asserts XML node is valid according to the given XML Schema."""
+        """Assert XML node is valid according to a XML Schema.
+
+        :param node: Node element to valid using an XML Schema
+        :param xschema: XMLSchema used to valid the given node element.
+                        Can be a string or an LXML XMLSchema element
+        :param filename: Path to the expected XMLSchema for validation.
+
+        This method tests if the given ``node`` complies with an XML schema.
+        This schema can be provided as a string, as a
+        :py:class:`lxml.etree.XMLSChema` object, or from a file (with the
+        ``filename`` parameter).
+
+        .. rubric:: Example using a filename
+
+        ::
+
+            def my_custom_test(self):
+                \"\"\"Check XML using XMLSchema at path/to/xschema.xml.
+
+                The content of the XMLSchema file is::
+
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <xsd:element name="root">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element
+                                    name="child"
+                                    minOccurs="1"
+                                    maxOccurs="1"
+                                >
+                                    <xsd:complexType>
+                                        <xsd:simpleContent>
+                                            <xsd:extension base="xsd:string">
+                                                <xsd:attribute
+                                                    name="id"
+                                                    type="xsd:string"
+                                                    use="required"
+                                                />
+                                            </xsd:extension>
+                                        </xsd:simpleContent>
+                                    </xsd:complexType>
+                                </xsd:element>
+                            </xsd:sequence>
+                        </xsd:complexType>
+                    </xsd:element>
+                    </xsd:schema>
+
+                \"\"\"
+                xschema_filename = 'path/to/xschema.xml'
+                data = \"\"\"<?xml version="1.0" encoding="utf-8"?>
+                <root>
+                    <child id="child1"/>
+                </root>
+                \"\"\"
+                root = test_case.assertXmlDocument(data.encode('utf-8'))
+                self.assertXmlValidXSchema(root, filename=xschema_filename)
+
+        """
         schema = None
 
         if xschema is not None and not isinstance(xschema, etree.XMLSchema):
@@ -254,9 +665,58 @@ class XmlTestMixin:
         if not schema.validate(node):
             self.fail(schema.error_log.last_error)
 
-    def assertXmlValidRelaxNG(self, node, relaxng=None, filename=None,
-                              encoding='utf-8'):
-        """Asserts XML node is valid according to the given RelaxNG."""
+    def assertXmlValidRelaxNG(
+        self,
+        node,
+        relaxng=None,
+        filename=None,
+        encoding='utf-8',
+    ):
+        """Assert XML node is valid according to a RelaxNG schema.
+
+        :param node: Node element to valid using a RelaxNG
+        :param relaxng: RelaxNG used to valid the given node element.
+                        Can be a string or an LXML RelaxNG element
+        :param filename: Path to the expected RelaxNG for validation.
+        :param encoding: expected encoding for the file
+
+        This method tests if the given ``node`` complies with a RelaxNG schema.
+        This schema can be provided as a string, as a
+        :py:class:`lxml.etree.RelaxNG` object, or from a file (with the
+        ``filename`` parameter).
+
+        .. rubric:: Example using a filename
+
+        ::
+
+            def my_custom_test(self):
+                \"\"\"Check XML generated using RelaxNG at path/to/relaxng.xml.
+
+                The content of the RelaxNG file is:
+
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <rng:element
+                        name="root"
+                        xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                    >
+                        <rng:element name="child">
+                            <rng:attribute name="id">
+                                <rng:text />
+                            </rng:attribute>
+                        </rng:element>
+                    </rng:element>
+
+                \"\"\"
+                relaxng_filename = 'path/to/relaxng.xml'
+                data = \"\"\"<?xml version="1.0" encoding="utf-8"?>
+                <root>
+                    <child id="child1"/>
+                </root>
+                \"\"\"
+                root = test_case.assertXmlDocument(data.encode('utf-8'))
+                self.assertXmlValidRelaxNG(root, filename=relaxng_filename)
+
+        """
         schema = None
 
         if relaxng is not None and not isinstance(relaxng, etree.RelaxNG):
@@ -265,7 +725,7 @@ class XmlTestMixin:
             schema = relaxng
 
         if relaxng is None and filename is not None:
-            with open(filename, 'r') as relaxng_file:
+            with open(filename, 'r', encoding=encoding) as relaxng_file:
                 schema = etree.RelaxNG(
                     etree.XML(relaxng_file.read().encode(encoding)))
 
@@ -275,15 +735,75 @@ class XmlTestMixin:
         if not schema.validate(node):
             self.fail(schema.error_log.last_error)
 
-    def assertXmlEquivalentOutputs(self, data, expected):
+    def assertXmlEquivalentOutputs(
+        self,
+        data: Union[str, bytes],
+        expected: Union[str, bytes],
+    ):
         """Asserts both XML outputs are equivalent.
 
-        This assertion use the powerful but dangerous feature of
-        LXMLOutputChecker. Powerful because one can compare two XML document
-        in their meaning, but dangerous because sometimes there is more to
-        check than just a kind of output.
+        :param data: XML formated string to check
+        :param expected: XML formated string used as reference
 
-        See LXMLOutputChecker documentation for more information.
+        This assertion uses the powerful but dangerous feature of
+        ``LXMLOutputChecker``. Powerful because one can compare two XML
+        document in their meaning, but dangerous because sometimes there is
+        more to check than just a kind of output.
+
+        See ``LXMLOutputChecker`` documentation for more information.
+
+        Asserts both XML formated string are equivalent. The comparison ignores
+        spaces within nodes and namespaces may be associated to diffrerent
+        prefixes, thus requiring only the same URL.
+
+        If a difference is found, an :py:exc:`AssertionError` is raised, with
+        the comparison failure's message as error's message.
+
+        .. note::
+
+            The name ``assertXmlEquivalentOutputs`` is a way to prevent
+            user to missunderstand the meaning of this assertion: it checks
+            only similar **outputs**, not **document**.
+
+        .. note::
+
+            This method only accept a string (either ``str`` or ``bytes``) as
+            arguments. This is an opinionated implementation choice, as the
+            purpose of this method is to check the result outputs of an XML
+            document, and not the document itself.
+
+        .. rubric:: Example
+
+        ::
+
+            # ...
+
+            def test_custom_test(self):
+                \"\"\"Same XML (with variable output)\"\"\"
+                # This XML string should come from the code one want to test
+                data = b\"\"\"<?xml version="1.0" encoding="UTF-8" ?>
+                <root><tag bar="foo" foo="bar"> foo </tag></root>\"\"\"
+
+                # This is the former XML document one can expect,
+                # pretty printed
+                expected = b\"\"\"<?xml version="1.0" encoding="UTF-8" ?>
+                <root>
+                    <tag foo="bar" bar="foo">foo</tag>
+                </root>\"\"\"
+
+                # This will pass
+                test_case.assertXmlEquivalentOutputs(data, expected)
+
+                # This is another example of result, with a missing attribute
+                data = b\"\"\"<?xml version="1.0" encoding="UTF-8" ?>
+                <root>
+                    <tag foo="bar"> foo </tag>
+                </root>
+                \"\"\"
+
+                # This won't pass
+                test_case.assertXmlEquivalentOutputs(data, expected)
+
         """
         checker = LXMLOutputChecker()
 
@@ -295,10 +815,19 @@ class XmlTestMixin:
 
 
 class XmlTestCase(unittest.TestCase, XmlTestMixin):
-    """XML test case for unit test using python unittest built-in package.
+    """Test case for XML document with ``lxml`` and ``unittest``.
 
-    One can extends this class for their test cases and use helpful assertion
-    methods.
+    This can serve as a base class for any test case using unittest::
 
-    XML parsing uses python lxml.etree.
+        import xmlunittest
+
+        class MyTestCase(xmlunittest.XmlTestCase):
+            def test_my_case(self):
+                # use XmlTestCase's assertion methods
+                ...
+
+    This class extends :py:class:`unittest.TestCase` and
+    :py:class:`XmlTestMixin`. If you want a description of assertion methods,
+    you should read next the description of base class
+    :py:class:`XmlTestMixin`.
     """


### PR DESCRIPTION
All the documentation written directly into `docs/`'s source files is now living in the code itself.